### PR TITLE
updated documentation for get_all_workouts and updated parse_dates fu…

### DIFF
--- a/R/parsing.R
+++ b/R/parsing.R
@@ -50,7 +50,7 @@ parse_dates <- function(dataframe, tz = "America/Los_Angeles") {
   for (i in seq_along(names)) {
     name <- names[i]
     # TODO parse inner list too
-    true[[i]] <- grepl(pattern = "^1[0-9]{9}", x = dataframe[[name]]) && !is.list(dataframe[[name]])
+    true[[i]] <- grepl(pattern = "^1[0-9]{9}", x = dataframe[[name]]) && !is.list(dataframe[[name]]) && name!="id"
   }
   vars <- names[true]
   dplyr::mutate_at(dataframe, vars, fn)

--- a/R/queries.R
+++ b/R/queries.R
@@ -52,10 +52,11 @@ get_perfomance_graphs <- function(workout_ids, every_n = 5) {
 #' Makes a request against the \code{api/user_id/workouts/} endpoint
 #'
 #'
-#' Lists (all?) workouts for a user, along with some metadata.
+#' Lists requested number of workouts for a user, along with some metadata.
 #'
 #' @export
 #' @param userid userID
+#' @param num_workouts num_workouts
 #' @examples
 #' \dontrun{
 #' peloton_auth()


### PR DESCRIPTION
Ben, I updated the documentation to reflect the earlier change.  Of course, feel free to keep, edit, or disregard. 

Also, in the API, you can request many many workouts over your max, I found out.  However, occasionally there are workout 'id's that your parse_dates function was catching as a date.  When it tried to convert it to a date it would error.  I made a small fix that disregarded the column if it was an id column.  This was true for my 116th workout.  

Now you can request way over your actual workout limit and it will return how many total workouts you have.  I have 175 workouts and they all work now.  