### PR TITLE
fixed a bug about peloton_id being treated as a date

### DIFF
--- a/R/parsing.R
+++ b/R/parsing.R
@@ -50,7 +50,7 @@ parse_dates <- function(dataframe, tz = base::Sys.timezone()) {
   for (i in seq_along(names)) {
     name <- names[i]
     # TODO parse inner list too
-    true[[i]] <- grepl(pattern = "^1[0-9]{9}", x = dataframe[[name]]) && !is.list(dataframe[[name]]) && !name %in% c("id", "facebook_id")
+    true[[i]] <- grepl(pattern = "^1[0-9]{9}", x = dataframe[[name]]) && !is.list(dataframe[[name]]) && !name %in% c("peloton_id","id", "facebook_id")
   }
   vars <- names[true]
   dplyr::mutate_at(dataframe, vars, fn)


### PR DESCRIPTION
My peloton id starts with 10 digits so added it to the ignored columns. 

Also have a better fix for hashes that should work for all the ids.

This would be replacing the line with
true[[i]] <- grepl("^1[0-9]{9}",x=dataframe[[name]]) && !grepl("[0-9a-f]{32}",x=dataframe[[name]]) && !is.list(dataframe[[name]])